### PR TITLE
Improve visibility and sizing of car action buttons

### DIFF
--- a/client/src/pages/owner/ManageCars.jsx
+++ b/client/src/pages/owner/ManageCars.jsx
@@ -144,24 +144,24 @@ const ManageCars = () => {
                   <div className='flex items-center gap-2 sm:gap-3'>
                     <button
                       onClick={()=> handleEditCar(car)}
-                      className='p-1.5 hover:bg-blue-50 rounded-md transition-colors'
+                      className='p-2 sm:p-3 hover:bg-blue-50 rounded-lg transition-colors border border-blue-200 bg-blue-25'
                       title='Edit car'
                     >
-                      <img src={assets.edit_icon} alt="" className='w-6 h-6 sm:w-8 sm:h-8'/>
+                      <img src={assets.edit_icon} alt="Edit" className='w-5 h-5 sm:w-6 sm:h-6'/>
                     </button>
                     <button
                       onClick={()=> handleToggleAvailability(car)}
-                      className='p-1.5 hover:bg-gray-100 rounded-md transition-colors'
+                      className='p-2 sm:p-3 hover:bg-gray-100 rounded-lg transition-colors border border-gray-200 bg-gray-25'
                       title={car.isAvaliable ? 'Hide car' : 'Show car'}
                     >
-                      <img src={car.isAvaliable ? assets.eye_close_icon : assets.eye_icon} alt="" className='w-6 h-6 sm:w-8 sm:h-8'/>
+                      <img src={car.isAvaliable ? assets.eye_close_icon : assets.eye_icon} alt="Toggle visibility" className='w-5 h-5 sm:w-6 sm:h-6'/>
                     </button>
                     <button
                       onClick={()=> handleDeleteCar(car)}
-                      className='p-1.5 hover:bg-red-50 rounded-md transition-colors'
+                      className='p-2 sm:p-3 hover:bg-red-50 rounded-lg transition-colors border border-red-200 bg-red-25'
                       title='Delete car'
                     >
-                      <img src={assets.delete_icon} alt="" className='w-6 h-6 sm:w-8 sm:h-8'/>
+                      <img src={assets.delete_icon} alt="Delete" className='w-5 h-5 sm:w-6 sm:h-6'/>
                     </button>
                   </div>
                 </td>


### PR DESCRIPTION
## Purpose
Fix visibility and sizing issues with the edit, visibility toggle, and delete buttons in the manage cars interface. The user reported that the edit button was not visible and that the visibility and delete buttons were too small.

## Code changes
- Enhanced button styling with borders and background colors for better visibility
- Increased button padding from `p-1.5` to `p-2 sm:p-3` for larger click areas
- Changed border radius from `rounded-md` to `rounded-lg` for improved appearance
- Added colored borders and subtle background colors to distinguish button types:
  - Edit button: blue border and background (`border-blue-200 bg-blue-25`)
  - Visibility button: gray border and background (`border-gray-200 bg-gray-25`) 
  - Delete button: red border and background (`border-red-200 bg-red-25`)
- Added descriptive alt text to button icons for better accessibility

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 18`

🔗 [Edit in Builder.io](https://builder.io/app/projects/e4a69cf9e7b84672a14163db7c599f71/pulse-lab)

👀 [Preview Link](https://e4a69cf9e7b84672a14163db7c599f71-pulse-lab.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e4a69cf9e7b84672a14163db7c599f71</projectId>-->
<!--<branchName>pulse-lab</branchName>-->